### PR TITLE
Two device id parameters are not required in request Device(Client): device/save (websocket)

### DIFF
--- a/integration-tests/ws-device.js
+++ b/integration-tests/ws-device.js
@@ -258,6 +258,7 @@ describe('WebSocket API Device', function () {
             }
 
             function createDevice(callback) {
+        	    device.id = deviceId;
             	device.networkId = networkId;
                 req.update(path.get(path.DEVICE, deviceId))
                     .params({jwt: utils.jwt.admin, data: device})


### PR DESCRIPTION
Two device id parameters are not required in request Device(Client): device/save (websocket)