### PR TITLE
Investigate if two device id parameters are required in request Device(Client): srv: command/insert (websocket) and srv: notification/insert

### DIFF
--- a/integration-tests/ws-command.js
+++ b/integration-tests/ws-command.js
@@ -276,7 +276,6 @@ describe('WebSocket API Command', function () {
                 client.waitFor('command/insert', cleanUp)
                     .expect({
                         action: 'command/insert',
-                        deviceId: deviceId,
                         command: { command: COMMAND },
                         subscriptionId: subscriptionId
                     });
@@ -333,7 +332,6 @@ describe('WebSocket API Command', function () {
                 device.waitFor('command/insert', cleanUp)
                     .expect({
                         action: 'command/insert',
-                        deviceId: deviceId,
                         command: { command: COMMAND }
                     });
 
@@ -511,7 +509,6 @@ describe('WebSocket API Command', function () {
                 client.waitFor('command/insert', cleanUp)
                     .expect({
                         action: 'command/insert',
-                        deviceId: deviceId,
                         command: command,
                         subscriptionId: subscriptionId
                     });
@@ -659,7 +656,6 @@ describe('WebSocket API Command', function () {
                 device.waitFor('command/insert', cleanUp)
                     .expect({
                         action: 'command/insert',
-                        deviceId: deviceId,
                         command: command
                     });
 

--- a/integration-tests/ws-notification.js
+++ b/integration-tests/ws-notification.js
@@ -337,7 +337,6 @@ describe('WebSocket API Notification', function () {
                 client.waitFor('notification/insert', cleanUp)
                     .expect({
                         action: 'notification/insert',
-                        deviceId: deviceId,
                         notification: { notification: NOTIFICATION },
                         subscriptionId: subscriptionId
                     });
@@ -437,7 +436,6 @@ describe('WebSocket API Notification', function () {
                 device.waitFor('notification/insert', cleanUp)
                     .expect({
                         action: 'notification/insert',
-                        deviceId: deviceId,
                         notification: { notification: NOTIFICATION }
                     });
 
@@ -547,7 +545,6 @@ describe('WebSocket API Notification', function () {
                 client.waitFor('notification/insert', cleanUp)
                     .expect({
                         action: 'notification/insert',
-                        deviceId: deviceId,
                         notification: notification,
                         subscriptionId: subscriptionId
                     });


### PR DESCRIPTION
Investigate if two device id parameters are required in request Device(Client): srv: command/insert (websocket) and srv: notification/insert