### PR TITLE
DEV-11 Returning error for non existent device when device/command/poll is performed

### DIFF
--- a/integration-tests/rest-device-command.js
+++ b/integration-tests/rest-device-command.js
@@ -372,7 +372,21 @@ describe('REST API Device Command', function () {
                     assert.strictEqual(!(!err), false, 'No error');
                 });
             }, 100);
-        })
+        });
+
+        it('should return an error when polling for the non existent device', function (done) {
+            var params = {jwt: jwt};
+            var deviceList = path.COMMAND.get(utils.NON_EXISTING_ID);
+            var $path = path.combine(deviceList, path.POLL);
+            params.query = path.query('waitTimeout', 3);
+            utils.get($path, params, function (err) {
+                assert.strictEqual(!(!err), true, 'Error object created');
+                assert.strictEqual(err.error, format('Device with such deviceId = %d not found',
+                    utils.NON_EXISTING_ID));
+                assert.strictEqual(err.httpStatus, status.NOT_FOUND);
+                done();
+            });
+        });
     });
 
     describe('#Poll limit', function () {


### PR DESCRIPTION
Returning error for non existent device when device/command/poll is performed