### PR TITLE
Lower websocket timeout

### DIFF
--- a/integration-tests/common/websocket.js
+++ b/integration-tests/common/websocket.js
@@ -98,7 +98,7 @@ Websocket.prototype = {
 
             self.context.handled = true;
             done(new Error('send() timeout: hasn\'t got message \'' + self.context.params.action + '\''));
-        }, 60000);
+        }, 10000);
     },
 
     waitFor: function (action, timeout, callback) {


### PR DESCRIPTION
Some tests in CI sometimes got timeouts.
Several such 1m timeouts lead to failed test due to 10m time limit in CI.